### PR TITLE
implements hook_field_settings_form and hook_file_download

### DIFF
--- a/recline.field.inc
+++ b/recline.field.inc
@@ -46,6 +46,29 @@ function recline_field_formatter_info() {
 }
 
 /**
+ * Implements hook_field_settings_form().
+ */
+function recline_field_settings_form($field, $instance, $has_data) {
+  $defaults = field_info_field_settings($field['type']);
+  $settings = array_merge($defaults, $field['settings']);
+
+  $scheme_options = array();
+  foreach (file_get_stream_wrappers(STREAM_WRAPPERS_WRITE_VISIBLE) as $scheme => $stream_wrapper) {
+    $scheme_options[$scheme] = $stream_wrapper['name'];
+  }
+
+  $form['uri_scheme'] = array(
+    '#type' => 'radios',
+    '#title' => t('Upload destination'),
+    '#options' => $scheme_options,
+    '#default_value' => $settings['uri_scheme'],
+    '#description' => t('Select where the final files should be stored. Private file storage has significantly more overhead than public files, but allows restricted access to files within this field.'),
+    '#disabled' => $has_data,
+  );
+  return $form;
+}
+
+/**
  * Implements hook_field_widget_info().
  */
 function recline_field_widget_info() {

--- a/recline.module
+++ b/recline.module
@@ -978,3 +978,12 @@ function recline_delimiters() {
     '+' => '+',
   );
 }
+
+
+/**
+ * Implements hook_file_download().
+ */
+function recline_file_download($uri, $field_type = 'file') {
+  return file_file_download($uri, 'recline_field');
+}
+


### PR DESCRIPTION
As specified here: https://github.com/nuams/dkan/issues/125

Recline could handle private files, attached commit is enough to handle private files correctly.
