### PR TITLE
Update recline.make

### DIFF
--- a/recline.make
+++ b/recline.make
@@ -5,3 +5,15 @@ libraries[recline][type] = libraries
 libraries[recline][download][type] = git
 libraries[recline][download][url] = "https://github.com/okfn/recline.git"
 libraries[recline][download][revision] = "7757e563ee180e136a8a4008b6ac7b7b56e3050f"
+
+libraries[deep_diff][type] = libraries
+libraries[deep_diff][download][type] = git
+libraries[deep_diff][download][url] = "https://github.com/flitbit/diff.git"
+libraries[deep_diff][directory_name] = deep_diff
+libraries[deep_diff][download][revision] = "07e91c624e5016be5c5c6560a9eabe49ef3ba2d0"
+
+libraries[recline_deeplink][type] = libraries
+libraries[recline_deeplink][download][type] = git
+libraries[recline_deeplink][download][url] = "https://github.com/NuCivic/recline-deeplink.git"
+libraries[recline_deeplink][directory_name] = recline_deeplink
+libraries[recline_deeplink][download][revision] = "3175e9332b5bee893ad2e4c3018b81d1b4cde455"


### PR DESCRIPTION
NuCivic/nucivic-internal#156
### Acceptance test
- [ ] git pull 
- [ ] drush make -v --no-core --yes sites/all/modules/recline/recline.make --no-cache
- [ ] cd sites/all/libraries
- [ ] ls -la
- [ ] recline-deeplink and deep_diff should be listed
