### PR TITLE
NuCivic/nucivic-internal#229 Fixing problem with ovelapping checkbox whe...

### DIFF
--- a/recline.app.js
+++ b/recline.app.js
@@ -113,7 +113,6 @@
     // again and again
     var createExplorer = function(dataset, state, settings) {
         // remove existing data explorer view
-
         var reload = false;
         if (window.dataExplorer) {
             window.dataExplorer.remove();
@@ -206,13 +205,12 @@
     };
 
     function resize (plot) {
-        addCheckbox();
         var itemWidth = computeWidth(plot, _.pluck(plot.getXAxes()[0].ticks, 'label'));
         var graph = dataExplorer.pageViews[1];
-        if(!isInverted()){
+        if(!isInverted() && $('#prevent-label-overlapping').is(':checked')){
             var canvasWidth = Math.min(itemWidth + labelMargin, maxLabelWidth) * plot.getXAxes()[0].ticks.length;
             var canvasContainerWith = $('.panel.graph').parent().width();
-            if(canvasWidth < canvasContainerWith || !$('#prevent-label-overlapping').is(':checked')){
+            if(canvasWidth < canvasContainerWith){
                 canvasWidth = canvasContainerWith;
             }
             $('.panel.graph').width(canvasWidth);
@@ -229,6 +227,7 @@
     function bindEvents (plot, eventHolder) {
         var p = plot || dataExplorer.pageViews[1].view.plot;
         resize(p);
+        setTimeout(addCheckbox, 0);
     };
 
     function processOffset (dataset) {
@@ -271,7 +270,7 @@
     };
 
     function addCheckbox() {
-        $control = $('#prevent-label-overlapping');
+        $control = $('.form-stacked:visible').find('#prevent-label-overlapping');
         if(!$control.length){
             $form = $('.form-stacked');
             $checkboxDiv = $('<div class="checkbox"></div>').appendTo($form);


### PR DESCRIPTION
...n enter from a saved state.

NuCivic/nucivic-internal#229
### Acceptance criteria
- [x] git pull
- [x] Goto to a saved state url
- [x] Checkbox should be present
## Notes

I was not able preserve this checkbox state when you change any control of the visualization because this is a workaround to avoid create a new graph view. I don't know if this is important. 
