### PR TITLE
Adding link and url formatters to recline

### DIFF
--- a/recline.field.inc
+++ b/recline.field.inc
@@ -31,21 +31,6 @@ function recline_field_info() {
 }
 
 /**
- * Implements hook_field_formatter_info().
- */
-function recline_field_formatter_info() {
-  $formatters = array(
-    'recline_default_formatter' => array(
-      'label' => t('Recline.js visualization'),
-      'field types' => array('recline_field', 'file'),
-      // TODO: add some settings.
-      'settings' => array(),
-    ),
-  );
-  return $formatters;
-}
-
-/**
  * Implements hook_field_settings_form().
  */
 function recline_field_settings_form($field, $instance, $has_data) {
@@ -294,21 +279,85 @@ function recline_field_delete($entity_type, $entity, $field, $instance, $langcod
 }
 
 /**
+ * Implements hook_field_formatter_info().
+ */
+function recline_field_formatter_info() {
+  $formatters = array(
+    'recline_default_formatter' => array(
+      'label' => t('Recline.js visualization'),
+      'field types' => array('recline_field', 'file'),
+      // TODO: add some settings.
+      'settings' => array(),
+    ),
+    'recline_link_formatter' => array(
+      'label' => t('Recline field link'),
+      'field types' => array('recline_field'),
+      'settings' => array(),
+    ),
+    'recline_url_formatter' => array(
+      'label' => t('Recline field URI'),
+      'field types' => array('recline_field'),
+      'settings' => array(),
+    ),
+  );
+  return $formatters;
+}
+
+/**
  * Implements hook_field_formatter_view().
  */
 function recline_field_formatter_view($entity_type, $entity, $field, $instance, $langcode, $items, $display) {
-
   $element = array();
-
-  foreach ($items as $delta => $item) {
-    $item['entity'] = $entity;
-    $element[$delta] = array(
-      '#theme' => 'recline_default_formatter',
-      '#item' => $item,
-    );
+  switch ($display['type']) {
+    case 'recline_default_formatter':
+    case 'recline_link_formatter':
+    case 'recline_url_formatter':
+      foreach ($items as $delta => $item) {
+        $item['entity'] = $entity;
+        $element[$delta] = array(
+          '#theme' => $display['type'],
+          '#item' => $item,
+        );
+      }
+    break;
   }
-
   return $element;
+}
+
+/**
+ * Returns HTML for link field formatter for recline field.
+ *
+ * @param array $variables
+ *   An associative array containing:
+ *   - item: Associative array of recline field
+ *
+ * @ingroup themeable
+ */
+function theme_recline_link_formatter($variables) {
+  $url = theme_recline_url_formatter($variables);
+  $output = l(
+    $variables['item']['filename'],
+    $url
+  );
+  return $output;
+}
+
+/**
+ * Returns HTML for url field formatter for recline field.
+ *
+ * @param array $variables
+ *   An associative array containing:
+ *   - item: Associative array of recline field
+ *
+ * @ingroup themeable
+ */
+function theme_recline_url_formatter($variables) {
+  $output = file_create_url($variables['item']['uri']);
+  $output = url(
+    $output,
+    array('absolute' => TRUE)
+  );
+  return $output;
 }
 
 /**
@@ -322,7 +371,10 @@ function recline_field_formatter_view($entity_type, $entity, $field, $instance, 
  */
 function theme_recline_default_formatter($variables) {
   $output = recline_default_formatter_output($variables);
-
+  // We should REALLY think about how we want to architecture this. I don't like
+  // the case by case thing going on here. We should provide a way of tying file
+  // extensions with render functions so people can hook on this field formatter
+  // for an extra set of mime types
   if (isset($variables['item']['filemime']) && $variables['item']['filemime'] == 'application/zip') {
     $uri = $variables['item']['uri'];
     if (is_numeric(strpos($uri, 'public://'))) {

--- a/recline.module
+++ b/recline.module
@@ -76,6 +76,14 @@ function recline_theme() {
       'variables' => array('item' => NULL),
       'file' => 'recline.field.inc',
     ),
+    'recline_link_formatter' => array(
+      'variables' => array('item' => NULL),
+      'file' => 'recline.field.inc',
+    ),
+    'recline_url_formatter' => array(
+      'variables' => array('item' => NULL),
+      'file' => 'recline.field.inc',
+    ),
     'recline_widget' => array(
       'render element' => 'element',
       'file' => 'recline.field.inc',


### PR DESCRIPTION
NuCivic/dkan#336
### Acceptance Test
#### Setup
- [x] create a dkan QA site to evaluate this -> http://336_url_field_formatter.dkan.qa.nuamsdev.com/ 
#### Link Formatter
- [x] Change dkan resource's field_upload display to `Recline field link`
- [x] Go to a resource page and check if the resource file is being render as an anchor tag
#### URL Formatter
- [x] Change dkan dataset's field_upload display to `Recline field URL`
- [x] Go to a resource page and check if the resource file is being render as a plain URL
#### Post Setup
- [x] delete dkan_dataset `336_url_field_formatter` branch
- [x] close NuCivic/dkan#344 and delete branch
