### PR TITLE
Make ajax call timeout configurable

### DIFF
--- a/recline.app.js
+++ b/recline.app.js
@@ -87,7 +87,7 @@
                     };
                 }
                 else {
-                    ajax_options.timeout = 500;
+                    ajax_options.timeout = Drupal.settings.recline.ajax_timeout;
                     ajax_options.error = function(x, t, m) {
                         if (t === "timeout") {
                             $('.data-explorer').append('<div class="messages status">File was too large or unavailable for preview.</div>');

--- a/recline.field.inc
+++ b/recline.field.inc
@@ -488,6 +488,7 @@ function recline_default_formatter_output($variables) {
         'uuid' => $uuid,
         'fileType' => $variables['item']['filemime'],
         'dkan' => $dkan,
+        'ajax_timeout' => variable_get(RECLINE_AJAX_CALL_TIMEOUT, RECLINE_AJAX_CALL_DEFAULT_TIMEOUT),
       );
       drupal_add_js($settings, 'setting');
     }
@@ -514,6 +515,7 @@ function recline_default_formatter_output($variables) {
       'embed' => 1,
       'fileType' => $variables['item']['filemime'],
       'dkan' => $dkan,
+      'ajax_timeout' => variable_get(RECLINE_AJAX_CALL_TIMEOUT, RECLINE_AJAX_CALL_DEFAULT_TIMEOUT),
     );
     drupal_add_js($settings, 'setting');
   }

--- a/recline.module
+++ b/recline.module
@@ -5,6 +5,9 @@
  * Integrates Recline.js visualization tools.
  */
 
+define('RECLINE_AJAX_CALL_TIMEOUT', 'recline_ajax_call_timeout');
+define('RECLINE_AJAX_CALL_DEFAULT_TIMEOUT', 500);
+
 module_load_include('inc', 'recline', 'recline.field');
 
 /**
@@ -13,6 +16,13 @@ module_load_include('inc', 'recline', 'recline.field');
 function recline_menu() {
   $items = array();
 
+  $items['admin/dkan/recline'] = array(
+    'title' => 'Recline Configuration',
+    'description' => 'Configurable items for recline module',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('recline_configuration_form'),
+    'access arguments' => array('access administration pages'),
+  );
   $items['node/%node/recline-embed'] = array(
     'title' => 'Embed',
     'page callback' => 'recline_embed',
@@ -22,6 +32,41 @@ function recline_menu() {
   );
 
   return $items;
+}
+
+/**
+ * Callback for admin/dkan/recline page.
+ */
+function recline_configuration_form() {
+  $form = array();
+  $form['description'] = array(
+    '#type' => 'markup',
+    '#markup' => '<p>' . t('
+      Recline\'s module configuration items'
+    ) . '</p>',
+  );
+  $form['ajax_timeout'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Preview ajax call timeout'),
+    '#element_validate' => array('element_validate_integer_positive'),
+    '#default_value' => variable_get(RECLINE_AJAX_CALL_TIMEOUT, RECLINE_AJAX_CALL_DEFAULT_TIMEOUT),
+  );
+  $form['submit'] = array(
+    '#type' => 'submit',
+    '#value' => 'Save',
+    '#submit' => array('recline_configuration_form_save'),
+  );
+  return $form;
+}
+
+/**
+ * Submit function for recline_configuration_form
+ */
+function recline_configuration_form_save($form, &$form_state) {
+  if (isset($form['ajax_timeout']['#value'])) {
+    variable_set(RECLINE_AJAX_CALL_TIMEOUT, $form['ajax_timeout']['#value']);
+    drupal_set_message(t('Recline Configuration saved'), 'status', FALSE);
+  }
 }
 
 /**


### PR DESCRIPTION
NuCivic/dkan#446
### Acceptance Test
- [x] Wait for QA PR for dkan (Use http://446_qa.dkan.qa.nuamsdev.com/)
- [x] Go to `/admin/dkan/recline` (Also available under DKAN/Recline Configuration)
- [x] Set a very fast timeout (10 miliseconds)
- [x] Go to `/dataset/afghanistan-election-districts/resource/097d9236-3577-411c-8152-4bb0e7132438`
- [x] I should see the `File was too large or unavailable for preview` message
- [x] Repeat incrementing the timeout till you've got a preview
