### PR TITLE
Change access arguments for config form

### DIFF
--- a/recline.module
+++ b/recline.module
@@ -35,6 +35,18 @@ function recline_menu() {
 }
 
 /**
+ * Implements hook_permission().
+ */
+function recline_permission() {
+  $permissions['access recline configuration'] = array(
+    'title' => t('Configure recline module items.'),
+    'description' => t('Access recline module configuration items.'),
+  );
+
+  return $permissions;
+}
+
+/**
  * Callback for admin/dkan/recline page.
  */
 function recline_configuration_form() {

--- a/recline.module
+++ b/recline.module
@@ -21,7 +21,7 @@ function recline_menu() {
     'description' => 'Configurable items for recline module',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('recline_configuration_form'),
-    'access arguments' => array('access administration pages'),
+    'access arguments' => array('access recline configuration'),
   );
   $items['node/%node/recline-embed'] = array(
     'title' => 'Embed',


### PR DESCRIPTION
I saw that the permission used to control the access to the recline config form (found in admin/dkan/recline) was too general (access administration pages), so we couldn't remove that permission without affecting other things, what I did in order to have a more controlled access to it was add a hook_permission  and change the access arguments to that form in order to use the new permission.
