### PR TITLE
Fix filters query construction for Datastore ckan backend

### DIFF
--- a/backend.ckan_get.js
+++ b/backend.ckan_get.js
@@ -137,7 +137,7 @@ this.recline.Backend.Ckan = this.recline.Backend.Ckan || {};
       var filters = "";
       if (data.filters) {
         for (var filter in data.filters) {
-          filters = "&filters[" + filter + "]=" + data.filters[filter];
+          filters += "&filters[" + filter + "]=" + data.filters[filter];
         }
       }
       var searchUrl = that.endpoint + '/3/action/datastore_search?=' + objToQuery(data) + filters;


### PR DESCRIPTION
https://jira.govdelivery.com/browse/CIVIC-1157

Original PR: https://github.com/NuCivic/lky/pull/69
Dkan issue: https://github.com/NuCivic/dkan/issues/895

Only the last filter was included in the api call due to missing string
concatenation.
