### PR TITLE
Add option to grab the preview url only

### DIFF
--- a/recline-embed-button.tpl.php
+++ b/recline-embed-button.tpl.php
@@ -11,6 +11,10 @@
 <div class="recline-embed">
   <a class="embed-link" href="#"><?php print t('Embed'); ?></a>
   <div class="embed-code-wrapper">
-    <textarea class="embed-code" style="height: 25px;" onclick="select()"><?php print $embed_url ?></textarea>
+    <textarea class="embed-code" style="height: 75px;width:100%;" onclick="select()"><?php print $embed_url ?></textarea>
+    <br>
+    <small>Data Preview URL</small>
+    <textarea class="preview-code" style="height: 75px;width:100%;max-width:100%" onclick="select()"><?php print $embed_url ?></textarea>
+    <br><br>
   </div>
 </div>

--- a/recline.js
+++ b/recline.js
@@ -205,9 +205,23 @@
       return function(state){
         var iframeOptions = _.clone(options);
         var iframeTmpl = _.template('<iframe width="<%= width %>" height="<%= height %>" src="<%= src %>" frameborder="0"></iframe>');
+        var previewTmpl = _.template('<%= src %>');
         _.extend(iframeOptions, {src: iframeOptions.src + '#' + (state.serializedState || '')});
         var html = iframeTmpl(iframeOptions);
         $('.embed-code').text(html);
+        var preview = previewTmpl(iframeOptions);
+        $('.preview-code').text(preview);
+      };
+    }
+
+    // Creates the preview url code.
+    function getPreviewCode (options){
+      return function(state){
+        var previewOptions = _.clone(options);
+        var previewTmpl = _.template('<%= src %>');
+        _.extend(previewOptions, {src: previewOptions.src + '#' + (state.serializedState || '')});
+        var html = previewTmpl(previewOptions);
+        $('.preview-url').text(html);
       };
     }
 


### PR DESCRIPTION
## Issue

civic-2710
## Description

Users may want to embed a recline preview on their page but it is hard to get just the preview url without the entire embed code as well.
## Steps to reproduce
1. Navigate to a resource page
2. Click the embed button
3. Try to copy just the src url from the embed code, confirm it is not possible without copying the entire block, pasting into a text editor, and then plucking the url out from the embed code.
## Acceptance Criteria
- [ ] When on a resource page I should see a second block below the 'Embed' code called 'Data Preview URL' that will give me the preview url to paste into the visualization embed panel.
- [ ] You can use the visualization embed feature to add a recline preview with the 'external' url option
## PR dependency

https://github.com/NuCivic/visualization_entity/pull/45
