### PR TITLE
Add support to fetch remote resources using dkan data proxy

### DIFF
--- a/recline.field.inc
+++ b/recline.field.inc
@@ -413,9 +413,7 @@ function theme_recline_default_formatter($variables) {
  */
 function recline_default_formatter_output($variables) {
   $file = $variables['item'];
-
   $url = file_create_url($file['uri']);
-
   $icon = '';
 
   $format = recline_get_data_type($file['filemime']);

--- a/recline.js
+++ b/recline.js
@@ -140,6 +140,8 @@
       var file = Drupal.settings.recline.file;
       var uuid = Drupal.settings.recline.uuid;
 
+      file = (location.origin !== (new URL(file)).origin) ? '/node/' + Drupal.settings.recline.uuid + '/data' : file;
+
       // Select the backend to use
       switch(getBackend(datastoreStatus, fileType)) {
         case 'csv':


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-3051
### Description

Use the dkan data proxy to load remote resources and prevent CORS issues. Dkan data proxy it's added in NuCivic/dkan_datastore#71. This change the recline script file to load remote resources using the dkan data proxy instead of trying to do it by fetching the original url.
### Acceptance criteria

After merge other PRs:
- [ ] Go to resource creation page
- [ ] Select the Remote file tab
- [ ] Fill the field with this value (or any remote resource not in demo.getdkan.com) https://data.ok.gov/sites/default/files/res_okstatestat_monthly_visits_4kkb-qkvv.csv
- [ ] Fill the title, check the grid display and save
- [ ] Grid with data should appear
### PR Dependencies

NuCivic/dkan_dataset#243
NuCivic/dkan_datastore#71
