### PR TITLE
Fix data preview error when size too big but file in datastore

### DIFF
--- a/recline.js
+++ b/recline.js
@@ -334,7 +334,7 @@
 
     // Init the multiview.
     function init () {
-      if(fileSize < maxSizePreview) {
+      if(fileSize < maxSizePreview || datastoreStatus) {
         dataset = new recline.Model.Dataset(getDatasetOptions());
         dataset.fetch().fail(showRequestError);
         views = createExplorer(dataset, state, dataExplorerSettings);


### PR DESCRIPTION
To reproduce problem on release branch:
1. Upload a file that's larger than the recline preview limit. Confirm that you do get the error message "File was too large or unavailable for preview." when viewing the resource
2. Import the file into the datastore. You should still see the error. This PR should fix
