### PR TITLE
Fix data preview error when size too big but file in datastore

### DIFF
--- a/dkan-module-init.sh
+++ b/dkan-module-init.sh
@@ -3,7 +3,7 @@
 DKAN_MODULE=`ls *.info | cut -d'.' -f1`
 
 # DKAN branch or tag to use.
-DKAN_VERSION="7.x-1.x"
+DKAN_VERSION="release-1-12"
 
 COMPOSER_PATH="$HOME/.config/composer/vendor/bin"
 

--- a/recline.js
+++ b/recline.js
@@ -20,6 +20,7 @@
         fileSize = Drupal.settings.recline.fileSize;
         fileType = Drupal.settings.recline.fileType;
         maxSizePreview = Drupal.settings.recline.maxSizePreview;
+        datastoreStatus = Drupal.settings.recline.datastoreStatus;
 
         dataExplorerSettings = {
           grid: Drupal.settings.recline.grid,
@@ -135,7 +136,6 @@
     // Returns the dataset configuration.
     function getDatasetOptions () {
       var datasetOptions = {};
-      var datastoreStatus = Drupal.settings.recline.datastoreStatus;
       var delimiter = Drupal.settings.recline.delimiter;
       var file = Drupal.settings.recline.file;
       var uuid = Drupal.settings.recline.uuid;
@@ -334,7 +334,7 @@
 
     // Init the multiview.
     function init () {
-      if(fileSize < maxSizePreview) {
+      if(fileSize < maxSizePreview || datastoreStatus) {
         dataset = new recline.Model.Dataset(getDatasetOptions());
         dataset.fetch().fail(showRequestError);
         views = createExplorer(dataset, state, dataExplorerSettings);


### PR DESCRIPTION
To reproduce problem on release branch:
1. Upload a file that's larger than the recline preview limit. Confirm that you do get the error message "File was too large or unavailable for preview." when viewing the resource (see [this example](http://dan.dkandemo.nuamsdev.com/dataset/calenviro/resource/e4c89295-8300-4b4b-8f81-0b31781881d5))
2. Import the file into the datastore. You should still see the error. This PR should fix
