### PR TITLE
Check to see if the bootstrap library is already loaded from the theme

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@
 ------------------
 Remove unneeded fields UI dependency.
 Upgraded included version of Recline.js library.
+Add a check to see if the bootstrap library is already loaded before adding it.
 
 7.x-1.1 2014-06-27
 ------------------

--- a/recline.module
+++ b/recline.module
@@ -191,14 +191,17 @@ function recline_libraries_info() {
         'css/map.css',
         'css/multiview.css',
         'css-site/pygments.css',
-        'vendor/bootstrap/3.2.0/css/bootstrap.css',
       ),
       'js' => array(
-        'vendor/bootstrap/3.2.0/js/bootstrap.js',
         'dist/recline.js',
       ),
     ),
   );
+
+  if(!is_boostrap_available()) {
+    $libraries['recline']['files']['js'][] = 'vendor/bootstrap/3.2.0/js/bootstrap.js';
+    $libraries['recline']['files']['css'][] = 'vendor/bootstrap/3.2.0/css/bootstrap.css';
+  }
 
   $libraries['lodash'] = array(
     'name' => 'lodash',
@@ -383,6 +386,28 @@ function recline_libraries_info() {
   );
 
   return $libraries;
+}
+
+/**
+ * Check if bootstrap is already added.
+ */
+function is_boostrap_available(){
+  global $theme;
+  $themes = list_themes();
+  $base_theme = drupal_find_base_themes($themes, $theme);
+
+  if($theme == 'nuboot_radix' || in_array('NuBoot Radix', $base_theme)) {
+    return TRUE;
+  } else {
+    $re = '/bootstrap(\\.min)?\\.js/';
+    $js = array_keys(drupal_add_js());
+    foreach ($js as $j) {
+      if(preg_match($re, $j)) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
 }
 
 /**


### PR DESCRIPTION
Replacement for https://github.com/NuCivic/recline/pull/53
### Description

Recline was created to work as a module that doesn't require dkan to work. However it needs the twitter bootstrap library that's also shipped with dkan. This causes a requirement conflict that I'm addressing by looking for the theme name first and then looking in the already added js files. 

This is not a bullet proof solution since developers could create a subtheme that add bootstrap from a template file. I didn't find any solution for such cases.
### Acceptance criteria
- [x] Install dkan as normal and replace recline with this branch
- [x] Go to any preview page
- [x] open the developer console (cmd + i)
- [x] go to sources tab
- [x] press cmd + o and look up for boostrap
- [x] bootstrap.js (or min.js) should be added only once
- [x] Topics dropdown should work
