### PR TITLE
[CIVIC-4971] Zip preview undefined property error

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,8 @@
 7.x-1.12.x
 ----------
 - Make recline previews work on subdir paths.
+- Graceful handeling of missing remote zip files during resource preview
+  generation.
 
 7.x-1.11 2016-02-03
 ------------------

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,8 +1,10 @@
+7.x-1.x
+-------
+- Improved handling of missing remote zip files during resource preview generation.
+
 7.x-1.12.x
 ----------
 - Make recline previews work on subdir paths.
-- Graceful handeling of missing remote zip files during resource preview
-  generation.
 
 7.x-1.11 2016-02-03
 ------------------

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ machine:
 
   # Version of ruby to use
   php:
-    version: '5.5.11'
+    version: '5.6.22'
 
   # Override /etc/hosts
   #hosts:
@@ -24,7 +24,6 @@ checkout:
   post:
     # Remove the extra composer stuff that circleci loads and that is causing conflicts with drush.
     - rm -rf ~/.composer
-
 ## Customize dependencies
 dependencies:
 
@@ -35,7 +34,9 @@ dependencies:
      #- "~/backups"
      #- "test/sites/default"
   pre:
-    - echo "memory_limit = 256M" > ~/.phpenv/versions/5.5.11/etc/conf.d/memory.ini
+    - rm /opt/circleci/php/$(phpenv global)/etc/conf.d/xdebug.ini
+    - echo "memory_limit = 256M" > $PHPENV_ROOT/versions/$(phpenv global)/etc/conf.d/memory.ini
+    - echo "always_populate_raw_post_data = -1" > $PHPENV_ROOT/versions/$(phpenv global)/etc/conf.d/deprecated.ini
   override:
     - mkdir $CIRCLE_ARTIFACTS/junit
     - 'bash dkan-module-init.sh --deps --build=$DATABASE_URL'

--- a/recline.theme.inc
+++ b/recline.theme.inc
@@ -14,6 +14,17 @@
 define('MAX_SIZE_PREVIEW_ZIP', 600000);
 
 /**
+ * Timeout limit for HEAD HTTP requests.
+ */
+define('RECLINE_REQUEST_TIMEOUT_HEAD', 2);
+
+/**
+ * Timeout limit for GET HTTP requests.
+ */
+define('RECLINE_REQUEST_TIMEOUT_GET', 10);
+
+
+/**
  * Returns HTML for an recline field formatter.
  *
  * @param array $variables
@@ -93,14 +104,23 @@ function theme_recline_default_formatter($vars) {
       $output['preview'] = recline_preview_geojson_leaflet($url);
       break;
     case 'zip':
+      $filename = FALSE;
+
       if (substr($vars['item']['uri'], 0, 4) != 'http') {
-        $output['preview'] = recline_preview_zip($vars['item']['uri']);
+        $filename = $vars['item']['uri'];
       }
       else {
+        // Make sure we have the information about the remote file.
         if (!isset($request)) {
-          $request = drupal_http_request($url, array('timeout' => 10));
+          // TODO we probably want to improve this by using the
+          // GetRemoteFileInfo helper class from dkan_dataset module.
+          $request = drupal_http_request($url, array('timeout' => RECLINE_REQUEST_TIMEOUT_HEAD, 'method' => 'HEAD'));
         }
-        if ($request->headers['content-length'] < MAX_SIZE_PREVIEW_ZIP) {
+
+        // Make sure that the request was successful and the target zip file
+        // does not excced the maximum allowed for previews.
+        if (isset($request->headers['content-length'])
+          && $request->headers['content-length'] < MAX_SIZE_PREVIEW_ZIP) {
           $ch = curl_init($url);
           $filename = file_directory_temp() . "/tmp-" . rand(100000, 999999) . ".zip";
           $fp = fopen($filename, "w");
@@ -114,13 +134,19 @@ function theme_recline_default_formatter($vars) {
           curl_exec($ch);
           curl_close($ch);
           fclose($fp);
-          $output['preview'] = recline_preview_zip($filename);
-        }
-        else {
-          $output['preview'] = recline_preview_unavailable();
         }
       }
+
+      // If a suitable file is found then passe it threw the preview function,
+      // else default to unavaiable.
+      if ($filename) {
+        $output['preview'] = recline_preview_zip($filename);
+      }
+      else {
+        $output['preview'] = recline_preview_unavailable();
+      }
       break;
+
     case 'html':
       $output['preview'] = recline_format_link_api($url);
       break;

--- a/recline.theme.inc
+++ b/recline.theme.inc
@@ -7,6 +7,7 @@
 
 /**
  * File size limit for remote zip files preview.
+ *
  * This is an arbitrary number 600000 = 600kb
  * If you need to increase this consider that
  * could slow down preview pages loading.
@@ -66,7 +67,7 @@ function theme_recline_default_formatter($vars) {
   $output = recline_build_icon($url, $type, $file['filename'], $file['filemime'], $file['filesize'], $description);
 
   if(!$type) {
-    $request = drupal_http_request($url, array('timeout' => 2, 'method' => 'HEAD'));
+    $request = drupal_http_request($url, array('timeout' => RECLINE_REQUEST_TIMEOUT_HEAD, 'method' => 'HEAD'));
     // When request fail.
     if ($request->code != 200) {
 
@@ -84,7 +85,7 @@ function theme_recline_default_formatter($vars) {
         // If request fail b/c either a 405 or 400 error then we perform
         // a new request using GET but setting a timeout to 10 to avoid
         // this request get blocked because a big file download.
-        $request = drupal_http_request($url, array('timeout' => 10));
+        $request = drupal_http_request($url, array('timeout' => RECLINE_REQUEST_TIMEOUT_GET));
         if ($request->code != 200) {
           $output['preview'] = recline_preview_unavailable();
           return drupal_render($output);
@@ -173,7 +174,7 @@ function theme_recline_default_formatter($vars) {
       $service_url = $wms_url . '?request=GetCapabilities&service=WMS';
       // If the initial request was sent without the correct endpoint.
       if (!isset($request->data) || empty($request->data) || preg_match('/The request not allowed/', $request->data)) {
-        $request = drupal_http_request($service_url, array('timeout' => 10));
+        $request = drupal_http_request($service_url, array('timeout' => RECLINE_REQUEST_TIMEOUT_GET));
       }
       if ($request->code != 200) {
         $output['preview'] = recline_preview_unavailable();
@@ -290,7 +291,7 @@ function recline_preview_unavailable() {
  * Prettify json.
  */
 function recline_preview_json($url) {
-  $response = drupal_http_request($url, array('timeout' => 5));
+  $response = drupal_http_request($url, array('timeout' => RECLINE_REQUEST_TIMEOUT_GET));
   if ($response->code == '200') {
     $data = $response->data;
   }
@@ -329,7 +330,7 @@ function recline_preview_json($url) {
  * Prettify xml.
  */
 function recline_prettify_xml($url) {
-  $response = drupal_http_request($url, array('timeout' => 5));
+  $response = drupal_http_request($url, array('timeout' => RECLINE_REQUEST_TIMEOUT_GET));
   if ($response->code == '200') {
     $data = recline_replace_lt_gt($response->data);
   }


### PR DESCRIPTION
Issue: CIVIC-4971

## Description
Trying to preview a zip file hosted remotely that does not exist anymore will generate the following error:
```
Notice: Undefined property: stdClass::$headers in theme_recline_default_formatter() (line 103 of <root>/dkan/modules/contrib/recline/recline.theme.inc)
```

## How to reproduce

1. Create a resource node with a remotely hosted zip file.
2. Remove the destination zip file (or make it unreachable).

**Expected**: Graceful handling of the missing file during preview.
**Actual**: preview function return errors.