### PR TITLE
Added function to check boostrap for embed recline. We are getting whitepage #CIVIC-5152

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,7 +1,7 @@
 7.x-1.12.x
 ----------
 - Make recline previews work on subdir paths.
-- Fixed problem loading boostrap library on embed pages.
+- Improved check used to determine if bootstrap is available.
 
 7.x-1.11 2016-02-03
 ------------------

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 7.x-1.12.x
 ----------
 - Make recline previews work on subdir paths.
+- Fixed problem loading boostrap library on embed pages.
 
 7.x-1.11 2016-02-03
 ------------------

--- a/recline.field.inc
+++ b/recline.field.inc
@@ -370,6 +370,12 @@ function theme_recline_url_formatter($variables) {
  * @ingroup themeable
  */
 function theme_recline_default_formatter($variables) {
+  if (recline_embedded()) {
+    $recline_path = libraries_get_path('recline');
+    drupal_add_js($recline_path . '/vendor/bootstrap/3.2.0/js/bootstrap.js');
+    drupal_add_css($recline_path . '/vendor/bootstrap/3.2.0/css/bootstrap.css');
+  }
+
   $output = recline_default_formatter_output($variables);
   // We should REALLY think about how we want to architecture this. I don't like
   // the case by case thing going on here. We should provide a way of tying file

--- a/recline.module
+++ b/recline.module
@@ -11,6 +11,13 @@ define('FILE_SIZE_PREVIEW_LIMIT', 3000000);
 module_load_include('inc', 'recline', 'recline.field');
 
 /**
+ * Check if a preview it's embedded or not.
+ */
+function recline_embedded() {
+  return menu_get_item(current_path())['path'] === 'node/%/recline-embed';
+}
+
+/**
  * Implements hook_menu().
  */
 function recline_menu() {


### PR DESCRIPTION
Ref: https://github.com/NuCivic/dkan/pull/1646

Fixed problem with loading boostrap libraries on embed page. In another case we are getting white page. I example file to reproduce is 
[Foreclosures_0.csv.zip](https://github.com/NuCivic/recline/files/676266/Foreclosures_0.csv.zip)


