### PR TITLE
Add tab delimiter to list of options

### DIFF
--- a/recline.js
+++ b/recline.js
@@ -157,6 +157,20 @@
             delimiter: delimiter
           };
           break;
+        case 'tsv':
+          datasetOptions = {
+            backend: 'csv',
+            url: file,
+            delimiter: delimiter
+          };
+          break;
+        case 'txt':
+          datasetOptions = {
+            backend: 'csv',
+            url: file,
+            delimiter: delimiter
+          };
+          break;
         case 'ckan':
           datasetOptions = {
             endpoint: 'api',
@@ -213,8 +227,14 @@
       var formats = {
         'csv': ['text/csv', 'csv'],
         'xls': ['application/vnd.ms-excel', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        'tsv': ['text/tab-separated-values', 'text/tsv', 'tsv', 'tab'],
+        'txt': ['text/plain', 'txt'],
       };
       var backend = _.findKey(formats, function(format) { return _.include(format, fileType) });
+
+      // If the backend is a txt but the delimiter is not a tab, we don't need
+      // to show it using the backend.
+      if (Drupal.settings.recline.delimiter !== "\t" && backend === 'txt') {return '';}
 
       // If the backend is an xls but the browser version is prior 9 then
       // we need to fallback to dataproxy

--- a/recline.module
+++ b/recline.module
@@ -552,7 +552,7 @@ function recline_delimiters() {
     ';' => ';',
     '|' => '|',
     '+' => '+',
-    '/t' => 'tab',
+    "\t" => 'tab',
   );
 }
 

--- a/recline.module
+++ b/recline.module
@@ -552,6 +552,7 @@ function recline_delimiters() {
     ';' => ';',
     '|' => '|',
     '+' => '+',
+    '/t' => 'tab',
   );
 }
 

--- a/recline.theme.inc
+++ b/recline.theme.inc
@@ -107,6 +107,7 @@ function theme_recline_default_formatter($vars) {
       break;
 
     case 'csv':
+    case 'tsv':
     case 'xls':
       $output['preview'] = recline_preview_multiview($vars);
       break;

--- a/recline.theme.inc
+++ b/recline.theme.inc
@@ -107,6 +107,7 @@ function theme_recline_default_formatter($vars) {
       break;
 
     case 'csv':
+    case 'txt':
     case 'tsv':
     case 'xls':
       $output['preview'] = recline_preview_multiview($vars);
@@ -573,6 +574,10 @@ function recline_preview_multiview($variables) {
     $graph = !$is_remote && !$show_all ? (int) $item['graph'] : 1;
     $map = !$is_remote && !$show_all ? (int) $item['map'] : 1;
     $embed = !empty($item['embed']) ? (int) $item['embed'] : 0;
+
+    if (pathinfo($item['uri'], PATHINFO_EXTENSION) === 'tab') {
+      $item['filemime'] = 'text/tab-separated-values';
+    }
 
     $settings['recline'] = array(
       'file' => $file_path,


### PR DESCRIPTION
## Description
Currently, we support CSV files that have , ; | or + delimiters. We have plans for adding support for TAB delimiters for csv files https://jira.govdelivery.com/browse/CIVIC-4335
.txt, .tsv, and .tab file extensions are also used for tab delimited files. The general format is TSV (Tab Separated Values).
We need to support these other file types and the TSV format selection when creating Resources.