### PR TITLE
Skip previewing if resource being rendered by search_api

### DIFF
--- a/recline.theme.inc
+++ b/recline.theme.inc
@@ -110,6 +110,14 @@ function theme_recline_default_formatter($vars) {
       }
     }
   }
+  
+  // Displaying previews breaks solr indexing.
+  // @TODO: Create a new display mode from search indexing and remove.
+  if (isset($vars['item']['entity']->search_api_language)) {
+    $output['preview'] = recline_preview_unavailable();
+    return drupal_render($output);
+  }
+
   switch ($type) {
     case 'json':
       $output['preview'] = recline_preview_json($url);


### PR DESCRIPTION
CIVIC-6300

DKAN is failing on sites with large XML or JSON resources when the search api module indexes the site, because rendering these previews in batches for the indexer is too resource-intensive. 

Really this change should be made elsewhere; recline shouldn't care about search api. A better solution would be to index a different display mode than default for indexing. Let's keep that in mind for a future release.

Try QA'ing by harvesting https://chhs.data.ca.gov/data.json.