### PR TITLE
Fixes arcgis remote_file previews.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,12 +2,11 @@
 machine:
 
   timezone:
-    America/New_York # Set the timezone
+    America/New_York
 
   # Version of ruby to use
   php:
     version: '5.6.22'
-
   # Override /etc/hosts
   #hosts:
     #circlehost: 127.0.0.1
@@ -18,12 +17,23 @@ machine:
     # For xvfb / selenium setup (not sure why)
     #DISPLAY: ':99.0'
     DATABASE_URL: mysql://ubuntu:@127.0.0.1:3306/circle_test
+    # Timeouts issues happen when selenium tries to spawn a new chrome
+    # instance. I've nail that down to this selenium issue
+    # https://github.com/SeleniumHQ/docker-selenium/issues/87
+    DBUS_SESSION_BUS_ADDRESS: /dev/null
 ## Customize checkout
 ## Note: Only post is supported.
 checkout:
   post:
     # Remove the extra composer stuff that circleci loads and that is causing conflicts with drush.
     - rm -rf ~/.composer
+
+## Unset secure_file_priv on mysql.
+database:
+  pre:
+    - echo -e 'secure_file_priv = ""' | sudo sh -c "cat >> /etc/mysql/my.cnf"
+    - sudo /usr/sbin/service mysql restart
+
 ## Customize dependencies
 dependencies:
 

--- a/js/restdataview.js
+++ b/js/restdataview.js
@@ -13,7 +13,7 @@
           opacity: 0.5,
           useCors: false
         }).addTo(map);
-        var query = L.esri.Tasks.query({
+        var query = L.esri.query({
           url: Drupal.settings.recline.url + '/0'
         });
         query.bounds(function(error, latLngBounds, response){

--- a/recline.theme.inc
+++ b/recline.theme.inc
@@ -33,7 +33,7 @@ define('RECLINE_REQUEST_TIMEOUT_GET', 10);
  *
  * @ingroup themeable
  */
-function theme_recline_default_formatter($vars) {
+function theme_recline_default_formatter(array $vars) {
   $type = NULL;
 
   // Embedded view doesn't use html.tpl.php template
@@ -246,8 +246,8 @@ function recline_preview_wms($url, $titles, $images, $north, $east, $south, $wes
   $output = "var map = L.map('map', {
         zoom: 7
       });";
-  drupal_add_js('https://cdn.jsdelivr.net/leaflet/1.0.2/leaflet.js', 'external');
-  drupal_add_css('https://cdn.jsdelivr.net/leaflet/1.0.2/leaflet.css', 'external');
+  drupal_add_js('https://cdn.jsdelivr.net/leaflet/1.0.3/leaflet.js', 'external');
+  drupal_add_css('https://cdn.jsdelivr.net/leaflet/1.0.3/leaflet.css', 'external');
   $output .= "var url = '" . $url . "';";
   $output .= "L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);";
   $output .= "var layers = ['" . implode(",", $titles) . "'];";
@@ -397,22 +397,17 @@ function recline_replace_lt_gt($data) {
  * Preview for arcgis and rest data.
  */
 function recline_preview_arcgis_feature($url) {
-  drupal_add_js('https://cdn.jsdelivr.net/leaflet/1.0.2/leaflet.js', 'external');
-  drupal_add_js('https:////cdn.jsdelivr.net/leaflet.esri/1.0.0/esri-leaflet.js', 'external');
-  drupal_add_css('https://cdn.jsdelivr.net/leaflet/1.0.2/leaflet.css', 'external');
+  drupal_add_js('https://cdn.jsdelivr.net/leaflet/1.0.3/leaflet.js', 'external');
+  drupal_add_js('https:////cdn.jsdelivr.net/leaflet.esri/2.0.8/esri-leaflet.js', 'external');
+  drupal_add_css('https://cdn.jsdelivr.net/leaflet/1.0.3/leaflet.css', 'external');
   drupal_add_css('body { margin:0; padding:0; } #rest-map { position: relative; height: 500px; width: 100%;}', 'inline');
   $lat = variable_get('recline_default_lat', "38");
   $lon = variable_get('recline_default_lon', "-99");
   $module_path = drupal_get_path('module', 'recline');
   drupal_add_js(array(
-    'recline' => array(
-      'url' => $url,
-      'lat' => $lat,
-      'lon' => $lon,
-    ),
-    'setting',
-  ));
-  drupal_add_js($module_path . '/restdataview.js');
+    'recline' => array('url' => $url, 'lat' => $lat, 'lon' => $lon),
+  ), 'setting');
+  drupal_add_js($module_path . 'js/restdataview.js');
   $output = array(
     'map' => array(
       '#type' => 'markup',
@@ -434,7 +429,7 @@ function recline_preview_geojson_leaflet($url) {
     return;
   }
   libraries_load('leaflet_markercluster');
-  $leaflet_imgs = libraries_get_path('recline') . '/vendor/leaflet/1.0.2/images/';
+  $leaflet_imgs = libraries_get_path('recline') . '/vendor/leaflet/1.0.3/images/';
   drupal_add_js('L.Icon.Default.imagePath = "/' . $leaflet_imgs . '"', 'inline');
   drupal_add_library('leaflet_widget', 'leaflet');
   $output = "var dataExtent = " . $geojson;
@@ -593,7 +588,7 @@ function recline_preview_multiview($variables) {
   // Update the leaflet library and test if this bug goes away.
   // That will involve a lot of QA but we have to do it a some point.
   if ($recline) {
-    $leaflet_imgs = $recline['library path'] . '/vendor/leaflet/1.0.2/images/';
+    $leaflet_imgs = $recline['library path'] . '/vendor/leaflet/1.0.3/images/';
     drupal_add_js('L.Icon.Default.imagePath = "/' . $leaflet_imgs . '"', 'inline');
   }
 


### PR DESCRIPTION
REF CIVIC-6341.

Description
===
Using this URL, I tested whether or not creating ArcGIS previews would work:

https://ndgishub.nd.gov/ArcGIS/rest/services/All_EmergencyServices/MapServer

When I uploaded it to the CA test site as a resource, I did not give it
a format. This led it to be rendered as HTML. After I changed it to format type
ArcGIS, the resource preview showed a map but no layers or features.

## Acceptance Criteria

Previews should render for the following:

https://ndgishub.nd.gov/ArcGIS/rest/services/All_EmergencyServices/MapServer

Should look like this:

![screen shot 2017-05-15 at 5 05 24 pm](https://user-images.githubusercontent.com/309671/28968970-a2ea7da2-78f0-11e7-8d2e-57aedf9ca9df.png)

http://ndgishub.nd.gov/arcgis/rest/services/All_Communications/MapServer

![screen shot 2017-05-15 at 4 56 11 pm](https://user-images.githubusercontent.com/309671/28968995-b9abae6c-78f0-11e7-8ca5-56908f159035.png)

http://bodemmaps.services.geodesk.nl/arcgis/rest/services/Bodemdata/Bodemdata_PROD/mapserver

![screen shot 2017-05-15 at 5 08 29 pm](https://user-images.githubusercontent.com/309671/28969008-c74f6126-78f0-11e7-95e1-14cedaacf9ff.png)
