### PR TITLE
Fix ESRI previews

### DIFF
--- a/js/restdataview.js
+++ b/js/restdataview.js
@@ -13,7 +13,7 @@
           opacity: 0.5,
           useCors: false
         }).addTo(map);
-        var query = L.esri.Tasks.query({
+        var query = L.esri.query({
           url: Drupal.settings.recline.url + '/0'
         });
         query.bounds(function(error, latLngBounds, response){

--- a/js/restdataview.js
+++ b/js/restdataview.js
@@ -7,17 +7,28 @@
     attach: function (context) {
       if (typeof Drupal.settings.recline !== 'undefined' && typeof Drupal.settings.recline.url !== 'undefined') {
         var map = L.map('rest-map').setView([Drupal.settings.recline.lat, Drupal.settings.recline.lon], 4);
-        L.esri.basemapLayer('Gray').addTo(map);
-        L.esri.dynamicMapLayer({
+        var baseLayer = L.esri.basemapLayer('Gray').addTo(map);
+        var fl = L.esri.dynamicMapLayer({
           url: Drupal.settings.recline.url,
           opacity: 0.5,
           useCors: false
         }).addTo(map);
-        var query = L.esri.query({
-          url: Drupal.settings.recline.url + '/0'
-        });
-        query.bounds(function(error, latLngBounds, response){
-          map.fitBounds(latLngBounds);
+        var bounds = L.latLngBounds([]);
+
+        fl.metadata(function(error, metadata){
+          let layersIds = metadata.layers.map(l => l.id);
+          let counter = sl.length;
+          layersIds.forEach(id => {
+            L.esri.query({
+              url: Drupal.settings.recline.url + '/' + id
+            }).bounds(function(error, latLngBounds, response){
+              counter--;
+              bounds.extend(latLngBounds);
+              if(!counter) {
+                map.fitBounds(bounds);
+              }
+            });
+          })
         });
       }
     }

--- a/recline.theme.inc
+++ b/recline.theme.inc
@@ -109,7 +109,7 @@ function theme_recline_default_formatter($vars) {
       }
     }
   }
-  
+
   // Displaying previews breaks solr indexing.
   // @TODO: Create a new display mode from search indexing and remove.
   if (isset($vars['item']['entity']->search_api_language)) {
@@ -416,7 +416,7 @@ function recline_replace_lt_gt($data) {
  */
 function recline_preview_arcgis_feature($url) {
   drupal_add_js('https://cdn.jsdelivr.net/leaflet/1.0.2/leaflet.js', 'external');
-  drupal_add_js('https:////cdn.jsdelivr.net/leaflet.esri/1.0.0/esri-leaflet.js', 'external');
+  drupal_add_js('https:////cdn.jsdelivr.net/leaflet.esri/2.0.0/esri-leaflet.js', 'external');
   drupal_add_css('https://cdn.jsdelivr.net/leaflet/1.0.2/leaflet.css', 'external');
   drupal_add_css('body { margin:0; padding:0; } #rest-map { position: relative; height: 500px; width: 100%;}', 'inline');
   $lat = variable_get('recline_default_lat', "38");
@@ -427,9 +427,8 @@ function recline_preview_arcgis_feature($url) {
       'url' => $url,
       'lat' => $lat,
       'lon' => $lon,
-    ),
-    'setting',
-  ));
+    )
+    ),'setting');
   drupal_add_js($module_path . '/restdataview.js');
   $output = array(
     'map' => array(


### PR DESCRIPTION
Ref: CIVIC-6341
Fixes NuCivic/dkan#2091

## Description
Previews for ESRI maps weren't working. This happened because the leaflet library was updated but the esri-library doesn't. 
Aside from this bug seems like users tend to use the wrong input for loading ESRI resources. These should be considered remote files and not APIs.

## QA Steps
- [x] Create a new resource
- [x] Chose the remote file tab
- [x] Fill with http://ndgishub.nd.gov/ArcGIS/rest/services/All_EmergencyServices/MapServer
- [x] Save
- [x] The preview should looks like in the following screenshot:

<img width="1235" alt="screen shot 2017-08-08 at 2 55 49 pm" src="https://user-images.githubusercontent.com/381224/29086687-c9b16886-7c49-11e7-8d5b-8b764bff2d94.png">

## Acceptance criteria
- Previews listed in the ticket CIVIC-6341 works