### PR TITLE
Fixed typo in installation section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ contents using Recline.js
 ## INSTALLATION
 
 
-+ Download the Reline.js library from https://github.com/okfn/recline 
++ Download the Recline.js library from https://github.com/okfn/recline 
 (zip file) and install in 'sites/all/libraries/'.
 + Enable recline module.
 


### PR DESCRIPTION
Changed "Reline.js" to "Recline.js". I'm assuming it's a typo since I can't find anything called "Reline" https://github.com/okfn/recline or https://github.com/NuCivic/recline.