### PR TITLE
Fix restdataview.js so that it is compatable with internet explorer 

### DIFF
--- a/js/restdataview.js
+++ b/js/restdataview.js
@@ -16,9 +16,9 @@
         var bounds = L.latLngBounds([]);
 
         fl.metadata(function(error, metadata){
-          let layersIds = metadata.layers.map(l => l.id);
+          let layersIds = metadata.layers.map(function(l) {return l.id});
           let counter = sl.length;
-          layersIds.forEach(id => {
+          layersIds.forEach(function(id) {
             L.esri.query({
               url: Drupal.settings.recline.url + '/' + id
             }).bounds(function(error, latLngBounds, response){


### PR DESCRIPTION
IE has no ES6 => simplified function syntax

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#Browser_compatibility