### PR TITLE
Issue GetDKAN/dkan#2756: avoid datastore query on recline previews.

### DIFF
--- a/backend.ckan_get.js
+++ b/backend.ckan_get.js
@@ -46,7 +46,7 @@ this.recline.Backend.Ckan = this.recline.Backend.Ckan || {};
       wrapper = my.DataStore(out.endpoint);
     }
     var dfd = new Deferred();
-    var jqxhr = wrapper.search({resource_id: dataset.id, limit: 0});
+    var jqxhr = wrapper.search({resource_id: dataset.id, limit: 0, q: ''});
 
     jqxhr.done(function(results, status, req) {
       if(results.error) {


### PR DESCRIPTION
connects GetDKAN/dkan/issues/2765
The issue is reported [here](https://github.com/GetDKAN/dkan/issues/2765). Basically I just avoided the datastore query.

## Steps to Reproduce

1. Import any resource to datastore.
2. Visit the resource
3. See query similar to 'query=dataset/gold-prices-london-1950-2008-monthly/resource/api/3/action/datastore_search' in the network tab of your browser.

## Acceptance Criteria

- [ ] Visiting recline does not produce query in the datastore
- [ ] Querying in recline still works (enter word in search and press "go")