### PR TITLE
GetDKAN/dkan#2994 Fix how the sort parameter is built

### DIFF
--- a/backend.ckan_get.js
+++ b/backend.ckan_get.js
@@ -133,7 +133,11 @@ this.recline.Backend.Ckan = this.recline.Backend.Ckan || {};
       for (var p in obj) {
         if (obj.hasOwnProperty(p)) {
           if (typeof obj[p] !== 'object') {
-            str += '&' + p + '=' + obj[p] ;
+            if(p == 'sort'){
+              str += '&' + p + '[' + obj[p].split(' ')[0] + ']' + '=' + obj[p].split(' ')[1] ;
+            }else{
+              str += '&' + p + '=' + obj[p] ;
+            }
           }
         }
       }


### PR DESCRIPTION
Build the sort query string as `&sort[x]=y` instead of `&sort=x y` for [#2994](https://github.com/GetDKAN/dkan/issues/2994) fixing.